### PR TITLE
Updating RegionsManger to unselect regions after register and updateTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 2.2.2
+*CT Library Changes*
+* Update `registerRegion()` in `RegionsManager` to unselect the region after it is registered.
+* Unselect all regions after updating tags in `updateTagsForSelectedRegions` in `RegionsManager`.
+
 ### 2.2.1 
 Update repo links and add new interface method `getAllRegions` in `RegionsManager`. Also available in `Editor` through `RM` or `api`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vott-ct",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vott-ct",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "CanvasTools editor for the VoTT project",
   "main": "./lib/js/ct.js",
   "types": "./lib/js/ct.d.ts",

--- a/src/canvastools/ts/CanvasTools/Region/RegionsManager.ts
+++ b/src/canvastools/ts/CanvasTools/Region/RegionsManager.ts
@@ -327,6 +327,10 @@ export class RegionsManager {
         regions.forEach((region) => {
             region.updateTags(tagsDescriptor, this.tagsUpdateOptions);
         });
+
+        regions.forEach((region) => {
+            region.unselect();
+        })
     }
 
     /**
@@ -844,6 +848,7 @@ export class RegionsManager {
         this.regions.push(region);
 
         this.menu.showOnRegion(region);
+        region.unselect();
     }
 
     /**


### PR DESCRIPTION
- Added the ability to unselect the region by default once its registered
- Also unselect the regions once we've updated tags for selected regions
- Added changelogs
- Upgraded package version
![vott_switch_tags](https://user-images.githubusercontent.com/52679808/68620589-a775db80-0482-11ea-9527-923cf8493dd8.gif)
