### PR TITLE
Users/lesam/keyboard 2 points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 2.2.7
+Keyboard controls are now available when using the RectSelector.
+
+### 2.2.6
+Bug fixes related to zoom feature
+
 ### 2.2.5
 *CT Library Changes*
 * `resetZoomOnContentLoad` is introduced on `ZoomManager` so that the zoom behavior can be reset before new content load.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vott-ct",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "CanvasTools editor for the VoTT project",
   "main": "./lib/js/ct.js",
   "types": "./lib/js/ct.d.ts",

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
@@ -307,6 +307,7 @@ export class RectSelector extends Selector {
         }
 
         if (e.keyCode === 32) {
+            e.preventDefault();
             if (!this.usingKeyboardCursor) {
                 // start keyboard mode
                 this.activateKeyboardCursor();
@@ -320,7 +321,7 @@ export class RectSelector extends Selector {
                 this.curKeyboardCross = this.crossA;
             }
         }
-        if (!e.ctrlKey && this.usingKeyboardCursor) {
+        if (!e.ctrlKey && this.isKeyboardControlKey(e.keyCode) && this.usingKeyboardCursor) {
             this.moveKeyboardCursor(e.keyCode);
         }
     }
@@ -352,26 +353,27 @@ export class RectSelector extends Selector {
         this.moveCross(this.crossB, curPoint);
     }
 
+    private isKeyboardControlKey(keyCode: number) {
+        return keyCode === 89 || keyCode === 72 || keyCode === 71 || keyCode === 74;
+    }
+
     private moveKeyboardCursor(keyCode: number) {
-        if (!(37 <= keyCode && keyCode <= 40)) {
-            return;
-        }
         const nextPos: IPoint2D = {x: this.curKeyboardCross.x, y: this.curKeyboardCross.y};
         switch (keyCode) {
             // up
-            case 38:
+            case 89:
                 nextPos.y -= 20;
                 break;
             // down
-            case 40:
+            case 72:
                 nextPos.y += 20;
                 break;
             // left
-            case 37:
+            case 71:
                 nextPos.x -= 20;
                 break;
             // right
-            case 39:
+            case 74:
                 nextPos.x += 20;
                 break;
             default:

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
@@ -353,7 +353,7 @@ export class RectSelector extends Selector {
                 this.moveCross(this.curKeyboardCross, this.crossB);
             }
         }
-        if (this.usingKeyboardCursor) {
+        if (!e.ctrlKey && this.usingKeyboardCursor) {
             this.moveKeyboardCursor(e.keyCode);
         }
     }
@@ -382,6 +382,7 @@ export class RectSelector extends Selector {
         }
 
         this.moveCross(this.curKeyboardCross, nextPos);
+        this.moveSelectionBox(this.selectionBox, this.crossA, this.crossB);
     }
 
     /**

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
@@ -55,12 +55,12 @@ export class RectSelector extends Selector {
     private selectionModificator: SelectionModificator = SelectionModificator.RECT;
 
     /**
-     * Internal flag for control mode.
+     * Internal flag to control keyboard cursor mode.
      */
     private usingKeyboardCursor: boolean = false;
 
     /**
-     * Internal reference to current cross the keyboard controls.
+     * Internal reference to the current keyboard cross element.
      */
     private curKeyboardCross: CrossElement;
 

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
@@ -286,7 +286,7 @@ export class RectSelector extends Selector {
             this.isTwoPoints = true;
         }
 
-        if (e.keyCode === 32) {
+        if (e.key === " ") {
             e.preventDefault();
             if (!this.usingKeyboardCursor) {
                 // start keyboard mode
@@ -301,8 +301,8 @@ export class RectSelector extends Selector {
                 this.curKeyboardCross = this.crossA;
             }
         }
-        if (!e.ctrlKey && this.isKeyboardControlKey(e.keyCode) && this.usingKeyboardCursor) {
-            this.moveKeyboardCursor(e.keyCode);
+        if (!e.ctrlKey && this.isKeyboardControlKey(e.key) && this.usingKeyboardCursor) {
+            this.moveKeyboardCursor(e.key);
         }
     }
 
@@ -381,33 +381,33 @@ export class RectSelector extends Selector {
     }
 
     /**
-     * Helper function to check if a keyCode is used for controlling the keyboard cursor.
-     * @param keyCode number
+     * Helper function to check if a key is used for controlling the keyboard cursor.
+     * @param key string
      */
-    private isKeyboardControlKey(keyCode: number) {
-        return keyCode === 72 || keyCode === 74 || keyCode === 75 || keyCode === 85;
+    private isKeyboardControlKey(key: string) {
+        return key === "u" || key === "h" || key === "j" || key === "k";
     }
     /**
      * Helper function for common logic to start a two point selection.
-     * @param keyCode number
+     * @param key string
      */
-    private moveKeyboardCursor(keyCode: number) {
+    private moveKeyboardCursor(key: string) {
         const nextPos: IPoint2D = {x: this.curKeyboardCross.x, y: this.curKeyboardCross.y};
-        switch (keyCode) {
+        switch (key) {
             // up
-            case 85:
+            case "u":
                 nextPos.y -= 20;
                 break;
             // down
-            case 74:
+            case "j":
                 nextPos.y += 20;
                 break;
             // left
-            case 72:
+            case "h":
                 nextPos.x -= 20;
                 break;
             // right
-            case 75:
+            case "k":
                 nextPos.x += 20;
                 break;
             default:

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
@@ -332,14 +332,17 @@ export class RectSelector extends Selector {
             } else if (this.usingKeyboardCursor && !this.capturingState) {
                 // set crossA
                 this.capturingState = true;
-                this.curKeyboardCross = this.crossB;
-                this.moveCross(this.crossB, this.crossA);
+                this.moveCross(this.crossB, this.curKeyboardCross);
                 this.moveSelectionBox(this.selectionBox, this.crossA, this.crossB);
                 this.showAll([this.crossA, this.crossB, this.selectionBox]);
+
+                if (typeof this.callbacks.onSelectionBegin === "function") {
+                    this.callbacks.onSelectionBegin();
+                }
+                this.curKeyboardCross = this.crossB;
             } else if (this.usingKeyboardCursor && this.capturingState) {
                 // set crossB
                 this.capturingState = false;
-                this.curKeyboardCross = this.crossA;
                 this.hideAll([this.crossB, this.selectionBox]);
 
                 if (typeof this.callbacks.onSelectionEnd === "function") {
@@ -350,7 +353,8 @@ export class RectSelector extends Selector {
 
                     this.callbacks.onSelectionEnd(RegionData.BuildRectRegionData(x, y, w, h));
                 }
-                this.moveCross(this.curKeyboardCross, this.crossB);
+                this.moveCross(this.crossA, this.curKeyboardCross);
+                this.curKeyboardCross = this.crossA;
             }
         }
         if (!e.ctrlKey && this.usingKeyboardCursor) {
@@ -359,6 +363,9 @@ export class RectSelector extends Selector {
     }
 
     private moveKeyboardCursor(keyCode: number) {
+        if (!(37 <= keyCode && keyCode <= 40)) {
+            return;
+        }
         const nextPos: IPoint2D = {x: this.curKeyboardCross.x, y: this.curKeyboardCross.y};
         switch (keyCode) {
             // up

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
@@ -60,7 +60,7 @@ export class RectSelector extends Selector {
     private usingKeyboardCursor: boolean = false;
 
     /**
-     * Internal flag for control mode.
+     * Internal reference to current cross the keyboard controls.
      */
     private curKeyboardCross: CrossElement;
 

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
@@ -231,28 +231,9 @@ export class RectSelector extends Selector {
                 }
             } else {
                 if (this.capturingState) {
-                    this.capturingState = false;
-                    this.hideAll([this.crossB, this.selectionBox]);
-
-                    if (typeof this.callbacks.onSelectionEnd === "function") {
-                        const x = Math.min(this.crossA.x, this.crossB.x);
-                        const y = Math.min(this.crossA.y, this.crossB.y);
-                        const w = Math.abs(this.crossA.x - this.crossB.x);
-                        const h = Math.abs(this.crossA.y - this.crossB.y);
-
-                        this.callbacks.onSelectionEnd(RegionData.BuildRectRegionData(x, y, w, h));
-                    }
-                    this.moveCross(this.crossA, p);
-                    this.moveCross(this.crossB, p);
+                    this.endTwoPointSelection(p);
                 } else {
-                    this.capturingState = true;
-                    this.moveCross(this.crossB, p);
-                    this.moveSelectionBox(this.selectionBox, this.crossA, this.crossB);
-                    this.showAll([this.crossA, this.crossB, this.selectionBox]);
-
-                    if (typeof this.callbacks.onSelectionBegin === "function") {
-                        this.callbacks.onSelectionBegin();
-                    }
+                    this.startTwoPointSelection(p);
                 }
             }
         });
@@ -331,35 +312,44 @@ export class RectSelector extends Selector {
                 this.activateKeyboardCursor();
             } else if (this.usingKeyboardCursor && !this.capturingState) {
                 // set crossA
-                this.capturingState = true;
-                this.moveCross(this.crossB, this.curKeyboardCross);
-                this.moveSelectionBox(this.selectionBox, this.crossA, this.crossB);
-                this.showAll([this.crossA, this.crossB, this.selectionBox]);
-
-                if (typeof this.callbacks.onSelectionBegin === "function") {
-                    this.callbacks.onSelectionBegin();
-                }
+                this.startTwoPointSelection(this.curKeyboardCross);
                 this.curKeyboardCross = this.crossB;
             } else if (this.usingKeyboardCursor && this.capturingState) {
                 // set crossB
-                this.capturingState = false;
-                this.hideAll([this.crossB, this.selectionBox]);
-
-                if (typeof this.callbacks.onSelectionEnd === "function") {
-                    const x = Math.min(this.crossA.x, this.crossB.x);
-                    const y = Math.min(this.crossA.y, this.crossB.y);
-                    const w = Math.abs(this.crossA.x - this.crossB.x);
-                    const h = Math.abs(this.crossA.y - this.crossB.y);
-
-                    this.callbacks.onSelectionEnd(RegionData.BuildRectRegionData(x, y, w, h));
-                }
-                this.moveCross(this.crossA, this.curKeyboardCross);
+                this.endTwoPointSelection(this.curKeyboardCross);
                 this.curKeyboardCross = this.crossA;
             }
         }
         if (!e.ctrlKey && this.usingKeyboardCursor) {
             this.moveKeyboardCursor(e.keyCode);
         }
+    }
+
+    private startTwoPointSelection(curPoint: IPoint2D) {
+        this.capturingState = true;
+        this.moveCross(this.crossB, curPoint);
+        this.moveSelectionBox(this.selectionBox, this.crossA, this.crossB);
+        this.showAll([this.crossA, this.crossB, this.selectionBox]);
+
+        if (typeof this.callbacks.onSelectionBegin === "function") {
+            this.callbacks.onSelectionBegin();
+        }
+    }
+
+    private endTwoPointSelection(curPoint: IPoint2D) {
+        this.capturingState = false;
+        this.hideAll([this.crossB, this.selectionBox]);
+
+        if (typeof this.callbacks.onSelectionEnd === "function") {
+            const x = Math.min(this.crossA.x, this.crossB.x);
+            const y = Math.min(this.crossA.y, this.crossB.y);
+            const w = Math.abs(this.crossA.x - this.crossB.x);
+            const h = Math.abs(this.crossA.y - this.crossB.y);
+
+            this.callbacks.onSelectionEnd(RegionData.BuildRectRegionData(x, y, w, h));
+        }
+        this.moveCross(this.crossA, curPoint);
+        this.moveCross(this.crossB, curPoint);
     }
 
     private moveKeyboardCursor(keyCode: number) {

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/RectSelector.ts
@@ -273,26 +273,6 @@ export class RectSelector extends Selector {
     }
 
     /**
-     * Helper function to start the use of keyboard cursor controls.
-     */
-    private activateKeyboardCursor() {
-        this.usingKeyboardCursor = true;
-        this.curKeyboardCross = this.crossA;
-        this.isTwoPoints = true;
-        this.capturingState = false;
-        this.showAll([this.crossA]);
-        this.hideAll([this.crossB, this.selectionBox]);
-    }
-
-    /**
-     * Helper function to stop the use of keyboard cursor controls.
-     */
-    private deactivateKeyboardCursor() {
-        this.usingKeyboardCursor = false;
-        this.curKeyboardCross = null;
-    }
-
-    /**
      * Listener for the key down event.
      * @param e KeyboardEvent
      */
@@ -326,64 +306,6 @@ export class RectSelector extends Selector {
         }
     }
 
-    private startTwoPointSelection(curPoint: IPoint2D) {
-        this.capturingState = true;
-        this.moveCross(this.crossB, curPoint);
-        this.moveSelectionBox(this.selectionBox, this.crossA, this.crossB);
-        this.showAll([this.crossA, this.crossB, this.selectionBox]);
-
-        if (typeof this.callbacks.onSelectionBegin === "function") {
-            this.callbacks.onSelectionBegin();
-        }
-    }
-
-    private endTwoPointSelection(curPoint: IPoint2D) {
-        this.capturingState = false;
-        this.hideAll([this.crossB, this.selectionBox]);
-
-        if (typeof this.callbacks.onSelectionEnd === "function") {
-            const x = Math.min(this.crossA.x, this.crossB.x);
-            const y = Math.min(this.crossA.y, this.crossB.y);
-            const w = Math.abs(this.crossA.x - this.crossB.x);
-            const h = Math.abs(this.crossA.y - this.crossB.y);
-
-            this.callbacks.onSelectionEnd(RegionData.BuildRectRegionData(x, y, w, h));
-        }
-        this.moveCross(this.crossA, curPoint);
-        this.moveCross(this.crossB, curPoint);
-    }
-
-    private isKeyboardControlKey(keyCode: number) {
-        return keyCode === 89 || keyCode === 72 || keyCode === 71 || keyCode === 74;
-    }
-
-    private moveKeyboardCursor(keyCode: number) {
-        const nextPos: IPoint2D = {x: this.curKeyboardCross.x, y: this.curKeyboardCross.y};
-        switch (keyCode) {
-            // up
-            case 89:
-                nextPos.y -= 20;
-                break;
-            // down
-            case 72:
-                nextPos.y += 20;
-                break;
-            // left
-            case 71:
-                nextPos.x -= 20;
-                break;
-            // right
-            case 74:
-                nextPos.x += 20;
-                break;
-            default:
-                break;
-        }
-
-        this.moveCross(this.curKeyboardCross, nextPos);
-        this.moveSelectionBox(this.selectionBox, this.crossA, this.crossB);
-    }
-
     /**
      * Listener for the key up event.
      * @param e KeyboardEvent
@@ -401,5 +323,98 @@ export class RectSelector extends Selector {
             this.moveCross(this.crossA, this.crossB);
             this.hideAll([this.crossB, this.selectionBox]);
         }
+    }
+
+    /**
+     * Helper function to start the use of keyboard cursor controls.
+     */
+    private activateKeyboardCursor() {
+        this.usingKeyboardCursor = true;
+        this.curKeyboardCross = this.crossA;
+        this.isTwoPoints = true;
+        this.capturingState = false;
+        this.showAll([this.crossA]);
+        this.hideAll([this.crossB, this.selectionBox]);
+    }
+
+    /**
+     * Helper function to stop the use of keyboard cursor controls.
+     */
+    private deactivateKeyboardCursor() {
+        this.usingKeyboardCursor = false;
+        this.curKeyboardCross = null;
+    }
+
+    /**
+     * Helper function for common logic to start a two point selection.
+     * @param curPoint IPoint2D
+     */
+    private startTwoPointSelection(curPoint: IPoint2D) {
+        this.capturingState = true;
+        this.moveCross(this.crossB, curPoint);
+        this.moveSelectionBox(this.selectionBox, this.crossA, this.crossB);
+        this.showAll([this.crossA, this.crossB, this.selectionBox]);
+
+        if (typeof this.callbacks.onSelectionBegin === "function") {
+            this.callbacks.onSelectionBegin();
+        }
+    }
+
+    /**
+     * Helper function for common logic to end a two point selection.
+     * @param curPoint IPoint2D
+     */
+    private endTwoPointSelection(curPoint: IPoint2D) {
+        this.capturingState = false;
+        this.hideAll([this.crossB, this.selectionBox]);
+
+        if (typeof this.callbacks.onSelectionEnd === "function") {
+            const x = Math.min(this.crossA.x, this.crossB.x);
+            const y = Math.min(this.crossA.y, this.crossB.y);
+            const w = Math.abs(this.crossA.x - this.crossB.x);
+            const h = Math.abs(this.crossA.y - this.crossB.y);
+
+            this.callbacks.onSelectionEnd(RegionData.BuildRectRegionData(x, y, w, h));
+        }
+        this.moveCross(this.crossA, curPoint);
+        this.moveCross(this.crossB, curPoint);
+    }
+
+    /**
+     * Helper function to check if a keyCode is used for controlling the keyboard cursor.
+     * @param keyCode number
+     */
+    private isKeyboardControlKey(keyCode: number) {
+        return keyCode === 72 || keyCode === 74 || keyCode === 75 || keyCode === 85;
+    }
+    /**
+     * Helper function for common logic to start a two point selection.
+     * @param keyCode number
+     */
+    private moveKeyboardCursor(keyCode: number) {
+        const nextPos: IPoint2D = {x: this.curKeyboardCross.x, y: this.curKeyboardCross.y};
+        switch (keyCode) {
+            // up
+            case 85:
+                nextPos.y -= 20;
+                break;
+            // down
+            case 74:
+                nextPos.y += 20;
+                break;
+            // left
+            case 72:
+                nextPos.x -= 20;
+                break;
+            // right
+            case 75:
+                nextPos.x += 20;
+                break;
+            default:
+                break;
+        }
+
+        this.moveCross(this.curKeyboardCross, nextPos);
+        this.moveSelectionBox(this.selectionBox, this.crossA, this.crossB);
     }
 }


### PR DESCRIPTION
This PR adds keyboard support for the RectSelector. While the RectSelector is active, the user can press space to activate keyboard controls.

After pressing space, the selection cross can be moved with the UHJK keys (the only arrow key-like arrangement of keys that doesn't overlap with existing hotkeys). The user then presses space again to set the selection crosses.

![yuh](https://user-images.githubusercontent.com/16407439/76450029-5b806800-638a-11ea-8777-75a94058a647.gif)