### PR TITLE
Rendering performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.2.20
+* Improve render time significantly, by caching values expensive svg calculation call
+* Remove unnecessary re-render calls on add new region and complete region
+
 ### 2.2.19
 * Small bug fixed with ghost anchor
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vott-ct",
-  "version": "2.2.19",
+  "version": "2.2.20",
   "description": "CanvasTools editor for the VoTT project",
   "main": "./lib/js/ct.js",
   "types": "./lib/js/ct.d.ts",

--- a/samples/editor-performance-test/css/index.css
+++ b/samples/editor-performance-test/css/index.css
@@ -1,0 +1,48 @@
+body {
+    margin: 20px;   
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+#controls div {
+    margin: 20px 0;
+}
+
+#canvasToolsDiv {        
+    display: grid;
+    width: calc(100% - 40px);
+    height: 600px;
+    grid-template-columns: 64px 1fr;
+    grid-template-rows: 100%;
+
+    margin:0;
+    background: rgb(64,64,64);
+}
+
+#toolbarDiv {
+    grid-row: 1;
+    grid-column: 1/2;
+    z-index: 10;
+}
+
+#toolbarDiv svg {
+    width: 64px;
+    height: 100%;
+    margin-right:5px;
+    background: #666;
+    box-shadow: 0 0 0.5px #999, 5px 0px 10px -5px rgb(0,0,0);
+}
+
+#selectionDiv {
+    grid-row: 1;
+    grid-column: 2/3;
+    justify-self: center;
+    align-self: center;
+    margin: 5px;
+    width: calc(100% - 10px);
+    height: calc(100% - 10px);
+    background: rgb(64,64,64);   
+}
+
+#editorDiv svg {
+    box-shadow: 0px 0px 0.25px #999, 0px 0px 10px rgb(0,0,0);
+}

--- a/samples/editor-performance-test/index.html
+++ b/samples/editor-performance-test/index.html
@@ -1,0 +1,234 @@
+<!doctype html>
+<html>
+
+<head>
+    <link rel="stylesheet" href="css/index.css" />
+    <title>CanvasTools Samples - Images Editor</title>
+</head>
+
+<body>
+    <h1>CanvasTools Samples - Images Editor</h1>
+    <div>Test the rendering speed of adding a lot of new polygon regions</div>
+    <div id="canvasToolsDiv">
+        <div id="toolbarDiv">
+        </div>
+        <div id="selectionDiv">
+            <div id="editorDiv"></div>
+        </div>
+    </div>
+
+    <div id="controls">
+        <div>
+            <label for="selectPolygonCount">Number of polygons to draw:</label>
+            <input type="range" min="5" max="2000" value="50" class="slider" id="selectPolygonCount" onchange="onChangeSelectPolygonCount(this.value)">
+            <label id="polygonCount"></label>
+            <br/>
+            <label for="imageSelect">Choose image: </label>
+            <select id="imageSelect">
+            </select>
+        </div>
+    </div>
+</body>
+<script src="./../shared/js/ct.js"></script>
+<script>
+    // The list of images
+    const images = [
+            {
+                path: "./../shared/media/background-cat-hd.jpg",
+                title: "Cat (HD)"
+            }
+        ];
+    let editor;
+    let currentImage;
+
+    document.addEventListener("DOMContentLoaded", (e) => {
+        // Get references for editor and toolbar containers
+        const editorContainer = document.getElementById("editorDiv");
+        const toolbarContainer = document.getElementById("toolbarDiv");
+
+        // Init the editor with toolbar.
+        editor = new CanvasTools.Editor(editorContainer).api;
+        editor.addToolbar(toolbarContainer, CanvasTools.Editor.FullToolbarSet, "./../shared/media/icons/");
+
+        let incrementalRegionID = 100;
+
+        // Add new region to the editor when new region is created
+        editor.onSelectionEnd = (regionData) => {
+            let id = (incrementalRegionID++).toString();
+
+            // Generate random tag
+            let tags = generateRandomTagsDescriptor();            
+            editor.addRegion(id, regionData, tags);
+            console.log(regionData);
+            console.log(RegionData);
+
+            console.log(`Created ${id}: {${regionData.x}, ${regionData.y}} x {${regionData.width}, ${regionData.height}}`);
+        };     
+        
+        // Log region manipulations
+        editor.onRegionMoveBegin = (id, regionData) => {
+            console.log(`Began moving ${id}: {${regionData.x}, ${regionData.y}} x {${regionData.width}, ${regionData.height}}`);
+        };
+        editor.onRegionMove = (id, regionData) => {
+            // console.log(`Moving ${id}: {${regionData.x}, ${regionData.y}} x {${regionData.width}, ${regionData.height}}`);
+        };
+        editor.onRegionMoveEnd = (id, regionData) => {
+            console.log(`Ended moving ${id}: {${regionData.x}, ${regionData.y}} x {${regionData.width}, ${regionData.height}}`);
+        };
+        editor.onRegionSelected = (id, multiselection) => {
+            console.log(`Selected ${id}: multiselection = ${multiselection}`);
+        }
+        editor.onRegionDelete = (id, regionData) => {
+            console.log(`Deleted ${id}: {${regionData.x}, ${regionData.y}} x {${regionData.width}, ${regionData.height}}`);
+        };
+
+        // Short references to Colors.* classes
+        const Color = CanvasTools.Core.Colors.Color;
+        const RGBColor = CanvasTools.Core.Colors.RGBColor;
+        const LABColor = CanvasTools.Core.Colors.LABColor;
+        const HSLColor = CanvasTools.Core.Colors.HSLColor;
+
+        // Collection of primary tags. Use Color class to define color.
+        const primaryTags = [
+            new CanvasTools.Core.Tag("Awesome", new Color("#c48de7")),
+            new CanvasTools.Core.Tag("Amazing", new Color("#3b1")),
+            new CanvasTools.Core.Tag("Brilliante", new Color("#f94c48")),
+        ];
+
+        // Collection of secondary tags. Use hex-string to define color.
+        const secondaryTags = [
+            new CanvasTools.Core.Tag("Yes", "#fff"),
+            new CanvasTools.Core.Tag("No", "#000"),
+            new CanvasTools.Core.Tag("Unknown", "#999"),
+        ];
+
+        // Collection of ternary tags. Use various color formats to define color.
+        const ternaryTags = [
+            new CanvasTools.Core.Tag("one", new Color(new RGBColor(0.55, 0.24, 0.25))),
+            new CanvasTools.Core.Tag("two", new Color(new HSLColor(0.32, 0.27, 0.51))),
+            new CanvasTools.Core.Tag("many", new Color(new LABColor(0.62, 0.50, -0.55))),
+        ]
+
+        // Randomly generate tags descriptor object
+        function generateRandomTagsDescriptor() {
+            const rnd = (n) => {
+                let r = Math.floor(Math.random() * n);
+                if (r === n) {
+                    r = n - 1;
+                }
+                return r;
+            };
+
+            const primaryTag = primaryTags[rnd(3)];
+            const secondaryTag = secondaryTags[rnd(3)];
+            const ternaryTag = ternaryTags[rnd(3)];
+
+            const r = Math.random();
+            let tags;
+            
+            if (r < 0.2) {
+                // Create tags descriptor passing all three tags 
+                tags = new CanvasTools.Core.TagsDescriptor(primaryTag, [secondaryTag, ternaryTag]);
+            } else if (requestAnimationFrame < 0.4) {
+                // Create tags descriptor without primary tag
+                tags = new CanvasTools.Core.TagsDescriptor(null, [secondaryTag, ternaryTag]);
+            } else if (r < 0.6) {
+                // Create tags descriptor defining only primary tags
+                tags = new CanvasTools.Core.TagsDescriptor(primaryTag);
+            } else if (r < 0.8) {
+                // Create tags descriptor passing array of tags
+                tags = new CanvasTools.Core.TagsDescriptor([primaryTag, secondaryTag]);
+            } else {
+                // Create tags descriptor without specifying tags
+                tags = new CanvasTools.Core.TagsDescriptor();
+            }
+            return tags;
+        };
+        
+        let imageIndex = 0;
+        // Init images selector
+        initImageSelect(images, (index, path) => {
+            imageIndex = index;
+            loadImage(path, (image) => {
+                editor.addContentSource(image);
+                currentImage = image;
+            });
+
+            // Delete current regions on image change
+            editor.deleteAllRegions();
+        });
+
+        // Load first image
+        loadImage(images[imageIndex].path, (image) => {
+            editor.addContentSource(image);
+            currentImage = image;
+        });
+    });
+
+    // Builds select element using provided list of images 
+    function initImageSelect(images, onSelect) {
+        var imageSelect = document.getElementById("imageSelect");
+
+        images.forEach((image) => {
+            let o = document.createElement("option");
+            o.text = image.title;
+            imageSelect.add(o);
+        })
+        imageSelect.selectedIndex = 0;
+
+        // Register listener for image change
+        imageSelect.addEventListener("change", (e) => {
+            let index = imageSelect.selectedIndex;
+            if (index >= 0 && index < images.length) {
+                onSelect(index, images[index].path);
+            }
+        });
+    }
+
+    // Load an image from specified path and notify when it is loaded.
+    function loadImage(path, onready) {
+        const image = new Image();
+        image.addEventListener("load", (e) => {
+            onready(e.target);                
+        });
+        image.src = path;
+    }
+
+    function convertToRegion(shape) {
+        const points = shape.coordinates;
+        const [maxXPoint, minXPoint] = [Math.max(...points.map(p => p.x)), Math.min(...points.map(p => p.x))];
+        const [maxYPoint, minYPoint] = [Math.max(...points.map(p => p.y)), Math.min(...points.map(p => p.y))];
+        return CanvasTools.Core.RegionData.BuildPolygonRegionData(
+            minXPoint,
+            minYPoint,
+            maxXPoint - minXPoint,
+            maxYPoint - minYPoint,
+            points
+        );
+    }
+
+    function onChangeSelectPolygonCount(total) {
+        const editorDiv = document.getElementsByClassName("CanvasToolsEditor")[0];
+        document.getElementById("polygonCount").innerHTML = total;
+        editor.deleteAllRegions();
+        for(let i = 0; i < total; i++) {
+            const polygon = { name: "Aardvark", coordinates: [] };
+            const polygonPoints = Math.floor(Math.random() * 15);
+            const centerPoint = { x: Math.random(), y: Math.random() };
+            for (let j = 0; j < polygonPoints + 4; j++) {
+                polygon.coordinates.push({
+                    x: Math.min(Math.max(centerPoint.x + (0.05 * ((2 * Math.random() - 1))), 0), 1) * editorDiv.clientWidth,
+                    y: Math.min(Math.max(centerPoint.y + (0.05 * ((2 * Math.random() - 1))), 0), 1) * editorDiv.clientHeight
+                });
+            }
+
+            editor.RM.addRegion(
+                `${i}-region`,
+                convertToRegion(polygon),
+                new CanvasTools.Core.TagsDescriptor([new CanvasTools.Core.Tag("Aardvark", "#dd0000")])
+            );
+        }
+    }
+</script>
+
+</html>

--- a/samples/shared/js/ct.js
+++ b/samples/shared/js/ct.js
@@ -1009,6 +1009,14 @@ class TagsComponent extends RegionComponent_1.RegionComponent {
         this.node = paper.g();
         this.node.addClass("tagsLayer");
     }
+    static getCachedBBox(primaryTagNode) {
+        const tagName = primaryTagNode.node.innerHTML;
+        if (TagsComponent.bboxCache[tagName]) {
+            return TagsComponent.bboxCache[tagName];
+        }
+        TagsComponent.bboxCache[tagName] = primaryTagNode.getBBox();
+        return TagsComponent.bboxCache[tagName];
+    }
     updateTags(tags, options) {
         this.tags = tags;
         this.tagsUpdateOptions = options;
@@ -1035,6 +1043,7 @@ class TagsComponent extends RegionComponent_1.RegionComponent {
     }
 }
 exports.TagsComponent = TagsComponent;
+TagsComponent.bboxCache = {};
 
 
 /***/ }),
@@ -2241,7 +2250,6 @@ class RegionsManager {
             this.addPolygonRegion(id, regionData, tagsDescriptor);
         }
         this.sortRegionsByArea();
-        this.redrawAllRegions();
         if (this.regionAnnouncer) {
             this.regionAnnouncer.innerHTML = tagsDescriptor.toString();
         }
@@ -2599,7 +2607,6 @@ class RegionsManager {
                 region.select();
                 this.menu.showOnRegion(region);
                 this.sortRegionsByArea();
-                this.redrawAllRegions();
             }
             this.callbacks.onRegionMoveEnd(region.ID, regionData);
         }
@@ -4363,7 +4370,7 @@ class TagsElement extends TagsComponent_1.TagsComponent {
         this.primaryTagNode = paper.circle(this.x, this.y, TagsElement.DEFAULT_PRIMARY_TAG_RADIUS);
         this.primaryTagNode.addClass("primaryTagPointStyle");
         this.secondaryTagsNode = paper.g();
-        this.secondaryTagsNode.addClass("secondatyTagsLayer");
+        this.secondaryTagsNode.addClass("secondaryTagsLayer");
         this.secondaryTags = [];
         this.node.add(this.primaryTagNode);
         this.node.add(this.secondaryTagsNode);
@@ -4712,7 +4719,7 @@ class TagsElement extends TagsComponent_1.TagsComponent {
             });
             if (rebuildTags) {
                 this.primaryTagText.node.innerHTML = (this.tags.primary !== null) ? this.tags.primary.name : "";
-                this.textBox = this.primaryTagText.getBBox();
+                this.textBox = TagsComponent_1.TagsComponent.getCachedBBox(this.primaryTagText);
             }
             const showTextLabel = (this.textBox.width + 10 <= this.width)
                 && (this.textBox.height <= this.height);
@@ -4925,7 +4932,7 @@ class TagsElement extends TagsComponent_1.TagsComponent {
         this.primaryTagBoundRect.addClass("primaryTagBoundRectStyle");
         this.primaryTagText = paper.text(this.x, this.y, "");
         this.primaryTagText.addClass("primaryTagTextStyle");
-        this.textBox = this.primaryTagText.getBBox();
+        this.textBox = TagsComponent_1.TagsComponent.getCachedBBox(this.primaryTagText);
         const pointsData = [];
         this.regionData.points.forEach((p) => {
             pointsData.push(p.x, p.y);
@@ -5439,7 +5446,7 @@ class TagsElement extends TagsComponent_1.TagsComponent {
         this.primaryTagNode.add(this.primaryTagBoundRect);
         this.primaryTagNode.add(this.primaryTagPolyline);
         this.secondaryTagsNode = paper.g();
-        this.secondaryTagsNode.addClass("secondatyTagsLayer");
+        this.secondaryTagsNode.addClass("secondaryTagsLayer");
         this.secondaryTags = [];
         this.node.add(this.primaryTagNode);
         this.node.add(this.secondaryTagsNode);
@@ -5747,7 +5754,7 @@ class TagsElement extends TagsComponent_1.TagsComponent {
                     });
                     if (rebuildTags) {
                         this.primaryTagText.node.innerHTML = (this.tags.primary !== null) ? this.tags.primary.name : "";
-                        this.textBox = this.primaryTagText.getBBox();
+                        this.textBox = TagsComponent_1.TagsComponent.getCachedBBox(this.primaryTagText);
                     }
                     const showTextLabel = (this.textBox.width + 10 <= this.width)
                         && (this.textBox.height <= this.height);
@@ -5974,14 +5981,14 @@ class TagsElement extends TagsComponent_1.TagsComponent {
         this.primaryTagRect.addClass("primaryTagRectStyle");
         this.primaryTagText = paper.text(this.x, this.y, "");
         this.primaryTagText.addClass("primaryTagTextStyle");
-        this.textBox = this.primaryTagText.getBBox();
+        this.textBox = TagsComponent_1.TagsComponent.getCachedBBox(this.primaryTagText);
         this.primaryTagTextBG = paper.rect(this.x, this.y, 0, 0);
         this.primaryTagTextBG.addClass("primaryTagTextBGStyle");
         this.primaryTagNode.add(this.primaryTagRect);
         this.primaryTagNode.add(this.primaryTagTextBG);
         this.primaryTagNode.add(this.primaryTagText);
         this.secondaryTagsNode = paper.g();
-        this.secondaryTagsNode.addClass("secondatyTagsLayer");
+        this.secondaryTagsNode.addClass("secondaryTagsLayer");
         this.secondaryTags = [];
         this.node.add(this.primaryTagNode);
         this.node.add(this.secondaryTagsNode);

--- a/samples/shared/js/ct.js
+++ b/samples/shared/js/ct.js
@@ -3489,6 +3489,8 @@ CanvasTools.Core = {
         Color: Color_1.Color,
     },
 };
+CanvasTools.RegionData = RegionData_1.RegionData;
+CanvasTools.TagsDescriptor = TagsDescriptor_1.TagsDescriptor;
 CanvasTools.Selection = {
     AreaSelector: AreaSelector_1.AreaSelector,
     SelectionMode: ISelectorSettings_1.SelectionMode,

--- a/src/canvastools/ts/CanvasTools/Region/Component/TagsComponent.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Component/TagsComponent.ts
@@ -7,9 +7,25 @@ import { ITagsUpdateOptions } from "../../Interface/ITagsUpdateOptions";
 import { RegionComponent } from "./RegionComponent";
 
 /**
- * An abstract visual component used internall do draw tags data for regions.
+ * An abstract visual component used internal do draw tags data for regions.
  */
 export abstract class TagsComponent extends RegionComponent {
+    /**
+     * Computing the bounding box of a given svg text element is an expensive rendering call,
+     * given tag styles don't change and there is a set number of primary tag names caching improves
+     * re-render performance significantly. https://bugzilla.mozilla.org/show_bug.cgi?id=1579181
+     * @param primaryTagNode a given tag node which the content string will be used to lookup in the cache
+     */
+    public static getCachedBBox(primaryTagNode: Snap.Element): Snap.BBox {
+        const tagName = primaryTagNode.node.innerHTML;
+        if (TagsComponent.bboxCache[tagName]) {
+            return TagsComponent.bboxCache[tagName];
+        }
+
+        TagsComponent.bboxCache[tagName] = primaryTagNode.getBBox();
+        return TagsComponent.bboxCache[tagName];
+    }
+    private static bboxCache: { [K: string]: Snap.BBox } = {};
     /**
      * The reference to region's `TagsDescriptor` object.
      */
@@ -62,7 +78,7 @@ export abstract class TagsComponent extends RegionComponent {
      * @param regionData - The `RegionData` object shared across components. Used also for initial setup.
      * @param tags - The `TagsDescriptor` object presenting colors and names for region tags.
      * @param styleId - The unique css style id for region.
-     * @param styleSheet - The regerence to the stylesheet object for rules insection.
+     * @param styleSheet - The reference to the stylesheet object for rules insertion.
      * @param tagsUpdateOptions - The settings for redrawing tags.
      */
     constructor(paper: Snap.Paper, paperRect: Rect, regionData: RegionData, tags: TagsDescriptor,
@@ -103,7 +119,7 @@ export abstract class TagsComponent extends RegionComponent {
     protected abstract initStyleMaps(tags: TagsDescriptor);
 
     /**
-     * Rebulds the tags elements. Should be redefined in child classes.
+     * Rebuilds the tags elements. Should be redefined in child classes.
      */
     protected abstract rebuildTagLabels();
 

--- a/src/canvastools/ts/CanvasTools/Region/Point/TagsElement.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Point/TagsElement.ts
@@ -206,7 +206,7 @@ export class TagsElement extends TagsComponent {
         this.primaryTagNode.addClass("primaryTagPointStyle");
 
         this.secondaryTagsNode = paper.g();
-        this.secondaryTagsNode.addClass("secondatyTagsLayer");
+        this.secondaryTagsNode.addClass("secondaryTagsLayer");
         this.secondaryTags = [];
 
         this.node.add(this.primaryTagNode);

--- a/src/canvastools/ts/CanvasTools/Region/Polygon/TagsElement.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Polygon/TagsElement.ts
@@ -95,7 +95,7 @@ export class TagsElement extends TagsComponent {
             // Update primary tag text
             if (rebuildTags) {
                 this.primaryTagText.node.innerHTML = (this.tags.primary !== null) ? this.tags.primary.name : "";
-                this.textBox = this.primaryTagText.getBBox();
+                this.textBox = TagsComponent.getCachedBBox(this.primaryTagText);
             }
 
             const showTextLabel = (this.textBox.width + 10 <= this.width)
@@ -337,7 +337,7 @@ export class TagsElement extends TagsComponent {
 
         this.primaryTagText = paper.text(this.x, this.y, "");
         this.primaryTagText.addClass("primaryTagTextStyle");
-        this.textBox = this.primaryTagText.getBBox();
+        this.textBox = TagsComponent.getCachedBBox(this.primaryTagText);
 
         const pointsData = [];
         this.regionData.points.forEach((p) => {

--- a/src/canvastools/ts/CanvasTools/Region/Polyline/TagsElement.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Polyline/TagsElement.ts
@@ -268,7 +268,7 @@ export class TagsElement extends TagsComponent {
         this.primaryTagNode.add(this.primaryTagPolyline);
 
         this.secondaryTagsNode = paper.g();
-        this.secondaryTagsNode.addClass("secondatyTagsLayer");
+        this.secondaryTagsNode.addClass("secondaryTagsLayer");
         this.secondaryTags = [];
 
         this.node.add(this.primaryTagNode);

--- a/src/canvastools/ts/CanvasTools/Region/Rect/TagsElement.ts
+++ b/src/canvastools/ts/CanvasTools/Region/Rect/TagsElement.ts
@@ -66,7 +66,7 @@ export class TagsElement extends TagsComponent {
                     // Update primary tag text
                     if (rebuildTags) {
                         this.primaryTagText.node.innerHTML = (this.tags.primary !== null) ? this.tags.primary.name : "";
-                        this.textBox = this.primaryTagText.getBBox();
+                        this.textBox = TagsComponent.getCachedBBox(this.primaryTagText);
                     }
 
                     const showTextLabel = (this.textBox.width + 10 <= this.width)
@@ -320,7 +320,7 @@ export class TagsElement extends TagsComponent {
 
         this.primaryTagText = paper.text(this.x, this.y, "");
         this.primaryTagText.addClass("primaryTagTextStyle");
-        this.textBox = this.primaryTagText.getBBox();
+        this.textBox = TagsComponent.getCachedBBox(this.primaryTagText);
 
         // bound to region???
         this.primaryTagTextBG = paper.rect(this.x, this.y, 0, 0);
@@ -331,7 +331,7 @@ export class TagsElement extends TagsComponent {
         this.primaryTagNode.add(this.primaryTagText);
 
         this.secondaryTagsNode = paper.g();
-        this.secondaryTagsNode.addClass("secondatyTagsLayer");
+        this.secondaryTagsNode.addClass("secondaryTagsLayer");
         this.secondaryTags = [];
 
         this.node.add(this.primaryTagNode);

--- a/src/canvastools/ts/CanvasTools/Region/RegionsManager.ts
+++ b/src/canvastools/ts/CanvasTools/Region/RegionsManager.ts
@@ -177,7 +177,6 @@ export class RegionsManager {
             this.addPolygonRegion(id, regionData, tagsDescriptor);
         }
         this.sortRegionsByArea();
-        this.redrawAllRegions();
         if (this.regionAnnouncer) {
             this.regionAnnouncer.innerHTML = tagsDescriptor.toString();
         }
@@ -779,7 +778,6 @@ export class RegionsManager {
                 region.select();
                 this.menu.showOnRegion(region);
                 this.sortRegionsByArea();
-                this.redrawAllRegions();
             }
             this.callbacks.onRegionMoveEnd(region.ID, regionData);
         } else if (state === ChangeEventType.SELECTIONTOGGLE && !this.justManipulated) {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -19,8 +19,8 @@
         ],
         "paths": {
         },
-        "outDir": "dist"
-        /* "outFile": "dist/ct.js" */
+        "outDir": "dist",
+        "outFile": "dist/ct.js"
     },
     "include": [     
         "src/canvastools/ts/*.ts"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -19,8 +19,8 @@
         ],
         "paths": {
         },
-        "outDir": "dist",
-        "outFile": "dist/ct.js"
+        "outDir": "dist"
+        /* "outFile": "dist/ct.js" */
     },
     "include": [     
         "src/canvastools/ts/*.ts"


### PR DESCRIPTION
- Remove unnecessary re-render calls
- Cache svg `.getBBox` call which [is very slow](https://bugzilla.mozilla.org/show_bug.cgi?id=1579181)

For a large number of bounding box or polygon annotations (200+) redraw times are significantly slower and can make the canvas almost unusable. 
### Rendering 200 random polygon regions before change
| Overall time|Callstack breakdown|
|-----|---|
|![image](https://user-images.githubusercontent.com/1487328/94962440-52342580-04ab-11eb-99d4-33b87a835baa.png)|![image](https://user-images.githubusercontent.com/1487328/94962674-af2fdb80-04ab-11eb-8678-dfcc4dbb6061.png)|

### Rendering 200 random polygon regions after change
| Overall time|Callstack breakdown|
|-----|---|
|![image](https://user-images.githubusercontent.com/1487328/94963312-ccb17500-04ac-11eb-9dda-8d71d11528a9.png)|![image](https://user-images.githubusercontent.com/1487328/94963417-f9fe2300-04ac-11eb-9e56-8fd17b128933.png)|

This is a 52x performance gain for the given example and really adds to the usability of the canvas with a large number of annotations 😄 

### Added performance testing page
![add more polygons](https://user-images.githubusercontent.com/1487328/95123183-6758c080-0706-11eb-9505-57c0c10de1c1.gif)
