### PR TITLE
Users/pritamd/zoom cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 2.3.1
+* Added a new ZoomType `CursorCenter` which allows users to set the zoom around cursor position.
+
 ### 2.3.0
 * Add an `enablePathRegions` editor configuration to enable/disable path region types (Bezier curve support).
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vott-ct",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "CanvasTools editor for the VoTT project",
   "main": "./lib/js/ct.js",
   "types": "./lib/js/ct.d.ts",

--- a/samples/editor-with-zoom/index.html
+++ b/samples/editor-with-zoom/index.html
@@ -11,7 +11,7 @@
     <div id="canvasToolsDiv">
         <div id="toolbarDiv">
         </div>
-        <div id="selectionDiv">
+        <div id="selectionDiv" onmousewheel="onWheelCapture(event)">
             <div id="editorDiv"></div>
         </div>
     </div>
@@ -69,16 +69,16 @@
                 title: "Snow"
             }, 
         ];
-
+    var editor;
     document.addEventListener("DOMContentLoaded", (e) => {
         // Get references for editor and toolbar containers
         const editorContainer = document.getElementById("editorDiv");
         const toolbarContainer = document.getElementById("toolbarDiv");
 
         // Init the editor with toolbar.
-        const editor = new CanvasTools.Editor(editorContainer, undefined, undefined, undefined, {
+        editor = new CanvasTools.Editor(editorContainer, undefined, undefined, undefined, {
             isZoomEnabled: true,
-            zoomType: 2
+            zoomType: 3
         }).api;
         editor.addToolbar(toolbarContainer, CanvasTools.Editor.RectToolbarSet, "./../shared/media/icons/");
 
@@ -177,6 +177,8 @@
             return tags;
         };
         
+
+        
         let imageIndex = 0;
         // Init images selector
         initImageSelect(images, (index, path) => {
@@ -260,6 +262,44 @@
             onReady(e.target);                
         });
         image.src = path;
+    }
+
+    function onWheelCapture(e) {
+        if (!e.ctrlKey && !e.shiftKey && e.altKey && editor) {
+            const cursorPos = getCursorPos(e);
+            if (e.deltaY < 0) {
+                editor.ZM.callbacks.onZoomingIn(cursorPos);
+            } else if (e.deltaY > 0) {
+                editor.ZM.callbacks.onZoomingOut(cursorPos);
+            }
+            e.stopImmediatePropagation();
+            e.stopPropagation();
+            e.preventDefault();
+        }
+    }
+
+    function getCursorPos(e) {
+        const editorContainer = document.getElementsByClassName("CanvasToolsEditor")[0];
+        var containerPos, x = 0, y = 0;
+        e = e || window.event;
+        /*get the x and y positions of the container:*/
+        containerPos = editorContainer.getBoundingClientRect();
+
+        /*get the x and y positions of the image:*/
+        var editorStyles = window.getComputedStyle(editorContainer);
+        var imagePos = {
+            left: containerPos.left + parseFloat(editorStyles.paddingLeft),
+            top: containerPos.top + parseFloat(editorStyles.paddingTop)
+        };
+
+
+        /*calculate the cursor's x and y coordinates, relative to the image:*/
+        x = e.pageX - imagePos.left;
+        y = e.pageY - imagePos.top;
+        /*consider any page scrolling:*/
+        x = x - window.pageXOffset;
+        y = y - window.pageYOffset;
+        return {x : x, y : y};
     }
 </script>
 

--- a/src/canvastools/ts/CanvasTools/CanvasTools.Editor.ts
+++ b/src/canvastools/ts/CanvasTools/CanvasTools.Editor.ts
@@ -1068,7 +1068,7 @@ export class Editor {
             // focus on the editor container div so that scroll bar can be used via arrow keys
             this.editorContainerDiv.focus();
 
-            // when the zooming is around the actual center of the image
+            // Case: 1: ZoomType.ImageCenter ---- when the zooming is around the actual center of the image
             if (this.zoomManager.zoomType === ZoomType.ImageCenter) {
                 if (this.editorContainerDiv.scrollHeight > this.editorContainerDiv.clientHeight) {
                     this.editorContainerDiv.scrollTop =
@@ -1081,44 +1081,8 @@ export class Editor {
                 }
             }
 
-            // when the zooming is around the center of the image currently in the view port of editor container.
-            if (this.zoomManager.zoomType === ZoomType.ViewportCenter) {
-                // get the current scroll position
-                const currentScrollPos = {
-                    left: this.editorContainerDiv.scrollLeft,
-                    top: this.editorContainerDiv.scrollTop,
-                };
-
-                // get the current center of the viewport
-                const currentCenterInView = {
-                    x: this.editorContainerDiv.clientWidth / 2 + currentScrollPos.left,
-                    y: this.editorContainerDiv.clientHeight / 2 + currentScrollPos.top,
-                };
-
-                // get the current center of the viewport once its is scaled based on zoom data
-                const zoomedCenterInView = {
-                    x: (currentCenterInView.x / zoomData.previousZoomScale) * zoomData.currentZoomScale,
-                    y: (currentCenterInView.y / zoomData.previousZoomScale) * zoomData.currentZoomScale
-                };
-
-                // get the difference between the expected scaled viewport center and current viewport center
-                const expectedScrollPosDifference = {
-                    left: zoomedCenterInView.x - currentCenterInView.x,
-                    top: zoomedCenterInView.y - currentCenterInView.y,
-                };
-
-                // get the expected scaled scroll position
-                const expectedScrollPos = {
-                    left: currentScrollPos.left + expectedScrollPosDifference.left,
-                    top: currentScrollPos.top + expectedScrollPosDifference.top,
-                };
-
-                this.editorContainerDiv.scrollLeft = expectedScrollPos.left;
-                this.editorContainerDiv.scrollTop = expectedScrollPos.top;
-            }
-
-            // when zooming is based on cursor position
-            if (this.zoomManager.zoomType === ZoomType.CursorCenter && cursorPos) {
+             // Case: 2: ZoomType.CursorCenter when zooming is based on cursor position
+             if (this.zoomManager.zoomType === ZoomType.CursorCenter && cursorPos) {
                 // get the current scroll position
                 const currentScrollPos = {
                     left: this.editorContainerDiv.scrollLeft,
@@ -1141,6 +1105,43 @@ export class Editor {
                  const expectedScrollPosDifference = {
                     left: scaledMousePos.x - mousePos.x,
                     top: scaledMousePos.y - mousePos.y,
+                };
+
+                // get the expected scaled scroll position
+                const expectedScrollPos = {
+                    left: currentScrollPos.left + expectedScrollPosDifference.left,
+                    top: currentScrollPos.top + expectedScrollPosDifference.top,
+                };
+
+                this.editorContainerDiv.scrollLeft = expectedScrollPos.left;
+                this.editorContainerDiv.scrollTop = expectedScrollPos.top;
+            }
+
+            // Case 3: ZoomType.ViewportCenter
+            // when the zooming is around the center of the image currently in the view port of editor container.
+            if (this.zoomManager.zoomType === ZoomType.ViewportCenter || !cursorPos) {
+                // get the current scroll position
+                const currentScrollPos = {
+                    left: this.editorContainerDiv.scrollLeft,
+                    top: this.editorContainerDiv.scrollTop,
+                };
+
+                // get the current center of the viewport
+                const currentCenterInView = {
+                    x: this.editorContainerDiv.clientWidth / 2 + currentScrollPos.left,
+                    y: this.editorContainerDiv.clientHeight / 2 + currentScrollPos.top,
+                };
+
+                // get the current center of the viewport once its is scaled based on zoom data
+                const zoomedCenterInView = {
+                    x: (currentCenterInView.x / zoomData.previousZoomScale) * zoomData.currentZoomScale,
+                    y: (currentCenterInView.y / zoomData.previousZoomScale) * zoomData.currentZoomScale
+                };
+
+                // get the difference between the expected scaled viewport center and current viewport center
+                const expectedScrollPosDifference = {
+                    left: zoomedCenterInView.x - currentCenterInView.x,
+                    top: zoomedCenterInView.y - currentCenterInView.y,
                 };
 
                 // get the expected scaled scroll position

--- a/src/canvastools/ts/CanvasTools/Core/ZoomManager.ts
+++ b/src/canvastools/ts/CanvasTools/Core/ZoomManager.ts
@@ -16,6 +16,14 @@ export interface ZoomProperties {
 }
 
 /**
+ * x and y are coordinates of cursor position on the image relative to zoomed/scaled image
+ */
+export interface CursorPosition {
+    x: number;
+    y: number;
+}
+
+/**
  * Enum indicating zoom behavior
  */
 export enum ZoomDirection {
@@ -36,6 +44,9 @@ export enum ZoomType {
     // This will zoom in/out based on the center of the portion of image currently visible
     // or view port of editor container
     ViewportCenter,
+
+    // This will zoom in/out based on the position of the cursor on the image
+    CursorCenter
 }
 
 /**
@@ -112,7 +123,7 @@ export class ZoomManager {
     /**
      * The factor or scale at which the zoom in / zoom out works incrementally.
      */
-    private zoomScale: number = 0.5;
+    private zoomScale: number = 0.1;
 
     /**
      * This holds the current scale at which the image is zoomed at.

--- a/src/canvastools/ts/CanvasTools/Interface/IZoomCallbacks.ts
+++ b/src/canvastools/ts/CanvasTools/Interface/IZoomCallbacks.ts
@@ -1,6 +1,6 @@
-import { ZoomData } from "../Core/ZoomManager";
+import { CursorPosition, ZoomData } from "../Core/ZoomManager";
 
-export type ZoomFunction = () => void;
+export type ZoomFunction = (cursorPos?: CursorPosition) => void;
 export type ZoomUpdateFunction = (zoomData: ZoomData) => void;
 /**
  * Defines a collection of callbacks passed to the `ZoomManager` constructor.


### PR DESCRIPTION
Added a new ZoomType `CursorCenter` which allows users to set the zoom around cursor position.

When zoomType is set to CursorCenter, the onZoomingIn() and onZoomingOut can take a param called cursorPos which would zoom in and out of relative cursor placement on the image

![VottZoomCursor](https://user-images.githubusercontent.com/29076912/158916595-1162c1cf-0da1-4dde-8808-46eced14f6c3.gif)

