### PR TITLE
Allow updating region visibility by region properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.3.3
+* Users of `RegionManager.updateRegionVisibility()` can now supply callbacks that can optionally accept region object in addition to tagsDescriptor for the `shouldHideThisRegion` parameter.
+* NOTE: The `tagsDescriptor` parameter will be removed in upcoming release and users are recommended to use `region.tag` in the callback body instead.
+
 ### 2.3.2
 * Expose getters to frameWidth and frameHeight on `Editor`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 ### 2.3.3
-* Users of `RegionManager.updateRegionVisibility()` can now supply callbacks that can optionally accept region object in addition to tagsDescriptor for the `shouldHideThisRegion` parameter.
+* Users of `RegionManager.updateRegionVisibility()` can now supply callbacks that can accept a region object in addition to tagsDescriptor for the `shouldHideThisRegion` parameter.
 * NOTE: The `tagsDescriptor` parameter will be removed in upcoming release and users are recommended to use `region.tag` in the callback body instead.
 
 ### 2.3.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vott-ct",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "CanvasTools editor for the VoTT project",
   "main": "./lib/js/ct.js",
   "types": "./lib/js/ct.d.ts",

--- a/src/canvastools/ts/CanvasTools/Region/RegionsManager.ts
+++ b/src/canvastools/ts/CanvasTools/Region/RegionsManager.ts
@@ -308,13 +308,15 @@ export class RegionsManager {
      * Allows for easy toggling of visibility of regions matching a predicate
      * @param shouldHideThisRegion the predicate for determining if a given `TagsDescriptor` and
      * its corresponding region should have its visibility changed
+     * @deprecated the `tagsDescriptor` parameter will be removed from the callback signature in the upcoming release.
+     * Instead, we recommend using `tags` property from the new region parameter.
      * @param shouldShow whether or not the regions found should be marked as visible or invisible
      */
     public updateRegionVisibility(
-        shouldHideThisRegion: (tagsDescriptor: TagsDescriptor) => boolean,
+        shouldHideThisRegion: (tagsDescriptor: TagsDescriptor, region?: Region) => boolean,
         shouldShow: boolean): void {
         this.regions.forEach((region) => {
-            if (shouldHideThisRegion(region.tags)) {
+            if (shouldHideThisRegion(region.tags, region)) {
                 if (shouldShow) {
                     region.show();
                 } else {

--- a/src/canvastools/ts/CanvasTools/Region/RegionsManager.ts
+++ b/src/canvastools/ts/CanvasTools/Region/RegionsManager.ts
@@ -306,14 +306,14 @@ export class RegionsManager {
 
     /**
      * Allows for easy toggling of visibility of regions matching a predicate
-     * @param shouldHideThisRegion the predicate for determining if a given `TagsDescriptor` and
-     * its corresponding region should have its visibility changed
-     * @deprecated the `tagsDescriptor` parameter will be removed from the callback signature in the upcoming release.
-     * Instead, we recommend using `tags` property from the new region parameter.
+     * @param shouldHideThisRegion accepts a `TagsDescriptor` and a `Region` to determine
+     * if that region should have its visibility changed. 
+     * @deprecated the `tagsDescriptor` parameter will be removed from the callback signature in the
+     * upcoming release. Instead, we recommend using `tags` property from the new region parameter.
      * @param shouldShow whether or not the regions found should be marked as visible or invisible
      */
     public updateRegionVisibility(
-        shouldHideThisRegion: (tagsDescriptor: TagsDescriptor, region?: Region) => boolean,
+        shouldHideThisRegion: (tagsDescriptor: TagsDescriptor, region: Region) => boolean,
         shouldShow: boolean): void {
         this.regions.forEach((region) => {
             if (shouldHideThisRegion(region.tags, region)) {


### PR DESCRIPTION
Signed-off-by: Harsh Upadhyay <haupadhy@microsoft.com>
Expanded the `updateRegionVisibility()` api to accept callbacks that can take a region in addition to the tagsDescriptor. We plan to deprecate the tagsDescriptor entirely since that information can be easily accessed from the region object that we are now accepting as the parameter. This allows user greater control over visibility of a particular region:
![image](https://user-images.githubusercontent.com/65194381/176515885-3cc28227-d284-421a-8d8d-575bef6b659d.png)
