### PR TITLE
avoid listening of escape key when it's not needed

### DIFF
--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/PolygonSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/PolygonSelector.ts
@@ -311,7 +311,7 @@ export class PolygonSelector extends Selector {
                 event: "keyup",
                 base: window,
                 listener: (e: KeyboardEvent) => {
-                    if (e.code === "Escape") {
+                    if (e.code === "Escape" && this.isCapturing) {
                         this.submitPolygon();
                     }
                 },

--- a/src/canvastools/ts/CanvasTools/Selection/Selectors/PolylineSelector.ts
+++ b/src/canvastools/ts/CanvasTools/Selection/Selectors/PolylineSelector.ts
@@ -336,7 +336,7 @@ export class PolylineSelector extends Selector {
      */
     private onKeyUp(e: KeyboardEvent) {
         // Holding shift key enable square drawing mode
-        if (e.code === "Escape") {
+        if (e.code === "Escape" && this.isCapturing) {
             this.submitPolyline();
         }
     }


### PR DESCRIPTION
to prevent an 'escape' key handling error